### PR TITLE
Sibling keys (design dead-end)

### DIFF
--- a/packages/contract/src/deployer.js
+++ b/packages/contract/src/deployer.js
@@ -13,6 +13,20 @@ const { isValidAddress, keccak } = require('ethereumjs-util')
 
 const deploys = {}
 
+/**
+ * Class encapsulating a deployer for a given network (chain ID)
+ * and inputter / outputter (possibly a remote data store)
+ * @memberof module:contract
+ * @param inputter {Function} a getter function, possibly async,
+ *   that takes a key and returns the associated value if it exists.
+ * @param outputter {Function} a setter function, possibly async,
+ *   that takes a key and a value as an Immutable Map, and returns
+ *   the written value, also as an Immutable Map.
+ * @param bm {Object} a BuildsManager, null if we want to auto-create one.
+ * @param eth {Object} an Ethereum network object
+ * @param chainId {String} the chain ID of the given eth, must match.
+ * @param address {String} the `0x`-prefixed Ethereum address to deploy from
+ */
 deploys.Deployer = class {
 
   constructor({inputter, outputter, bm, eth, chainId, address}) {
@@ -36,6 +50,7 @@ deploys.Deployer = class {
    * @param deployId {String} ID of previous deploy
    * @param ctorArgs {Immutable Map} of constructor arguments, can be empty Map or null
    * @param fork {boolean} whether to fork the given deploy at the current timestamp
+   *   can be left null for false
    */
   async deploy(contractName, linkId, deployId, ctorArgs, fork) {
     const linkName   = `${contractName}-${linkId}`
@@ -115,7 +130,7 @@ deploys.Deployer = class {
     })
 
     // This is an updated deploy, overwrite it
-    return this.bm.setDeploy(deployName, deployOutput, true)
+    return this.bm.setDeploy(deployName, deployOutput, true, fork)
   }
 
 }

--- a/packages/contract/tests/fork.spec.js
+++ b/packages/contract/tests/fork.spec.js
@@ -35,7 +35,7 @@ describe('Democracy forking', () => {
     deploy = await d.deploy('DifferentSender', 'link', 'deploy', Map({}), true)
     deploy2 = await d.deploy('DifferentSender', 'link', 'deploy', Map({}), true)
     LOGGER.info('deploy1 time', deploy.get('deployTime') )
-    LOGGER.info('deploy2 time', deploy.get('deployTime') )
+    LOGGER.info('deploy2 time', deploy2.get('deployTime') )
     assert( deploy.get('deployTime') < deploy2.get('deployTime') )
   })
 
@@ -50,9 +50,16 @@ describe('Democracy forking', () => {
     assert.equal( lastValue2, 3344 )
   })
 
+  it( 'retrieves back forked deploys', async () => {
+    const ddeploy = await bm.getDeploy('DifferentSender-deploy', deploy.get('deployTime') )
+    const ddeploy2 = await bm.getDeploy('DifferentSender-deploy', deploy2.get('deployTime') )
+    assert.equal( ddeploy.get('deployTime'), deploy.get('deployTime') )
+    assert.equal( ddeploy2.get('deployTime'), deploy2.get('deployTime') )
+  })
+
   after( async () => {
-    await bm.cleanDeploy( 'DifferentSender-deploy' )
-    await bm.cleanLink(   'DifferentSender-link'   )
+//    await bm.cleanDeploy( 'DifferentSender-deploy' )
+//    await bm.cleanLink(   'DifferentSender-link'   )
   })
 
 })

--- a/packages/contract/tests/fork.spec.js
+++ b/packages/contract/tests/fork.spec.js
@@ -1,0 +1,58 @@
+const { Deployer, Linker, isLink, isDeploy, Contract } = require('..')
+const { getNetwork, Logger } = require('demo-utils')
+const { Map } = require('immutable')
+
+const LOGGER = new Logger('fork.spec')
+
+const chai = require('chai').use(require('chai-as-promised'));
+const assert = chai.assert
+const BN = require('bn.js')
+
+let networkId
+
+describe('Democracy forking', () => {
+
+  let eth
+  let accounts
+  let d
+  let bm
+  let deploy
+  let deploy2
+
+  before(async () => {
+    eth = getNetwork()
+    accounts = await eth.accounts()
+    networkId = await eth.net_version()
+    d = new Deployer({eth: eth, chainId: networkId, address: accounts[0] })
+    bm = d.getBuildsManager()
+    l = new Linker({bm: bm, chainId: networkId})
+    await bm.cleanDeploy( 'DifferentSender-deploy' )
+    await bm.cleanLink( 'DifferentSender-link' )
+  })
+
+  it( 'creates two forked deploys' , async () => {
+    const link = await l.link( 'DifferentSender','link' )
+    deploy = await d.deploy('DifferentSender', 'link', 'deploy', Map({}), true)
+    deploy2 = await d.deploy('DifferentSender', 'link', 'deploy', Map({}), true)
+    LOGGER.info('deploy1 time', deploy.get('deployTime') )
+    LOGGER.info('deploy2 time', deploy.get('deployTime') )
+    assert( deploy.get('deployTime') < deploy2.get('deployTime') )
+  })
+
+  it( 'sends different values on different forks', async () => {
+    const c  = new Contract({ deployerEth: eth, deploy: deploy })
+    const c2 = new Contract({ deployerEth: eth, deploy: deploy2 })
+    await c.getInstance().send(accounts[0], {value: new BN(1122), from: accounts[0]})
+    await c2.getInstance().send(accounts[0], {value: new BN(3344), from: accounts[0]})
+    const lastValue = (await c.getInstance().lastValue())['0']
+    assert.equal( lastValue, 1122 )
+    const lastValue2 = (await c2.getInstance().lastValue())['0']
+    assert.equal( lastValue2, 3344 )
+  })
+
+  after( async () => {
+    await bm.cleanDeploy( 'DifferentSender-deploy' )
+    await bm.cleanLink(   'DifferentSender-link'   )
+  })
+
+})

--- a/packages/rest/src/server.js
+++ b/packages/rest/src/server.js
@@ -116,6 +116,29 @@ server.RESTServer = class {
       res.json(deploys.toJS())
     })
 
+    _router.route('/deploys/:chainId/:deployName/:forkTime').get((req, res) => {
+      const chainId    = req.params.chainId
+      const deployName = req.params.deployName
+      const forkTime   = req.params.forkTime
+      const deploy     = get(`/${DEPLOYS_DIR}/${chainId}/${deployName}/${forkTime}`, new Map({}))
+      res.json(deploy.toJS())
+    })
+
+    _router.route('/deploys/:chainId/:deployName/:forkTime').post((req, res) => {
+      const chainId    = req.params.chainId
+      const deployName = req.params.deployName
+      const forkTime   = req.params.forkTime
+      const jsBody     = fromJS(req.body)
+      const overwrite  = (req.headers['democracy-overwrite'] === 'true')
+      try {
+        const result = set(`/${DEPLOYS_DIR}/${chainId}/${deployName}/${forkTime}`, jsBody, overwrite)
+        res.json({result: result, body: jsBody})
+      } catch(e) {
+        LOGGER.error('Failed to set key:', e, chainId, deployName)
+        res.json({result: false, error: e})
+      }
+    })
+
     _router.route('/deploys/:chainId/:deployName').get((req, res) => {
       const chainId = req.params.chainId
       const deployName = req.params.deployName

--- a/packages/utils/src/db.js
+++ b/packages/utils/src/db.js
@@ -69,7 +69,7 @@ store.setImmutableKey = (fullKey, value, overwrite) => {
       fs.renameSync(`${dbFile}`, `${dbFile}.${now}`) 
       return true
     } else { 
-      throw new Error(`Key ${dbFile} exists and is not a JSON file.`)
+      LOGGER.debug(`Adding a file ${dbFile} with sibling directory of same base name.`)
     }
   } else if (!value) {
     //LOGGER.debug(`Unnecessary deletion of non-existent key ${fullKey}`)

--- a/packages/utils/tests/db.spec.js
+++ b/packages/utils/tests/db.spec.js
@@ -46,7 +46,7 @@ describe('Database tests for key/value store', () => {
   })
 
   it('cannot overwrite an existing key by accident', () => {
-    should.Throw(() => { setImmutableKey('someSpace', new Map({'c':3})) }, Error)
+    should.Throw(() => { setImmutableKey('someSpace/b', new Map({'c':3})) }, Error)
   })
 
   it('can overwrite a key explicitly', () => {
@@ -62,6 +62,11 @@ describe('Database tests for key/value store', () => {
     const val2 = getImmutableKey('anotherSpace')
     assert.equal(val2.count(), 1)
     assert.equal(val2.get('a').get('c'), 1)
+  })
+
+  it( 'can set sibling keys to a directory', () => {
+    assert(setImmutableKey('someSpace', new Map({'e':6, 'f':7})),
+          `Setting sibling keys {e:6, f:7} fails`)
   })
 
   it('overwrites a directory with a null', () => {


### PR DESCRIPTION
To allow forked deploys for parallel reproducible testing and public forks, it is useful to
store some (parent) keys at the parent level, and the child keys as contained files in the parent directory with the same basename.

Example directory structure
```
  ContractName-deploy/
    forkTime1.json # contains child keys for forkTime1
    forkTime2.json # contains child keys for forkTime2
  ContractName-deploy.json # contains parent keys that are equally applicable to forkTime1 and forkTime2
```

This would be the result of running the following writes
```
set('ContractName-deploy/forkTime1', Map({a:1}))
set('ContractName-deploy/forkTime2', Map({b:2}))
set('ContractName-deploy', Map({c:3}))
```

The read semantics seem clear, merging the child keys and the parent keys from the sibling directory+file.
```
get('ContractName-deploy') ->
  {
    'forkTime1': {'a': 1},
    'forkTime2': {'b': 2},
    'c': 3
  }
```

However, now the write semantics are confusing. If we write to the parent key, should we now check all the child keys and create JSON files for them? What if previous child keys are now missing? How do we decide which child keys to put into JSON files versus making them parent keys in the sibling file?

In general, this violates a principle of "There's only one way to do it".
The preferred way to solve this is to explicitly create a "parent" child, in this case, with a perhaps redundant name of 'deploy'

```
set('ContractName-deploy/forkTime1', Map({a:1}))
set('ContractName-deploy/forkTime2', Map({b:2}))
set('ContractName-deploy/deploy', Map({c:3}))
```

The read semantics are still clear, with one more level of indirection for the parent keys that used to be in the sibling file
```
get('ContractName-deploy') ->
  {
    'forkTime1': {'a': 1},
    'forkTime2': {'b': 2},
    'deploy': {'c': 3},
  }
```

Long story short, this is a design dead-end and we record it here for completeness, and will delete the branch and close this PR as won't fix.
