### PR TITLE
[transform] Improve error reporting for object types

### DIFF
--- a/packages/transform/src/types.ts
+++ b/packages/transform/src/types.ts
@@ -45,8 +45,13 @@ export const makeCheckerFromBoolean = (
   booleanChecker : BooleanArgCheckerFunc,
   typeName       : string,
 ): ArgCheckerFunc => {
-  return (arg: any) => booleanChecker(arg) ?
-    {} : {error: `Arg ${arg} did not have type ${typeName}`}
+  return (arg: any) => {
+    const argString = (typeof(arg) === 'object') ?
+      `object with keys ${JSON.stringify(Imm.List(Imm.Map(arg).keys()).toJS())}` :
+      JSON.stringify(arg)
+    return booleanChecker(arg) ?
+      {} : {error: `Arg ${argString} did not have type ${typeName}`}
+  }
 }
 
 export const makeRequired = (checkerFunc: ArgCheckerFunc, typeName: string): ArgType => {

--- a/packages/transform/tests/types.spec.ts
+++ b/packages/transform/tests/types.spec.ts
@@ -2,11 +2,28 @@
 
 import { assert } from 'chai'
 import { TYPES, isHexPrefixed } from '../src/types'
+const { wallet } = require('demo-keys')
 
 describe('Democracy types', () => {
 
   const prefixedKeccakHash =
     '0x09a33449c7526a56e658aff99a93a4dd8bf0788aeba88ba65cd94f35e1b4af19'
+
+  it('check that objects are stringified to their keys', async () => {
+    await wallet.init({ autoConfig: true })
+    const w = await wallet.prepareSignerEth({})
+    const result = TYPES.ethereumSigner(w)
+    assert.equal(
+      result['error'], 'Arg object with keys ["address","password","signerEth"] did not have type ethereumSigner',
+      'Return value of prepareSignerEth needs to be destructured.'
+    )
+    const { signerEth } = w
+    const result2 = TYPES.ethereumSigner(signerEth)
+    assert.notOk(
+      result2['error'],
+      'Destructured signerEth should now be a valid ethereumSigner'
+    )
+  })
 
   it('checks floatString type', async () => {
 


### PR DESCRIPTION
 by dumping their keys.

Test on the result of `await demo.keys.wallet.prepareSignerEth({})` and `TYPES.ethereumSigner`
See `tests/type.ts` for the usage of `prepareSignerEth` and the expected error message when used incorrectly.